### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The easiest way to get up and running is to load jQuery Contextify using a CDN. 
 ```
 or
 ```html
-<script src="//cdn.jsdelivr.net/jquery.contextify/1.0.8/jquery.contextify.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/jquery-contextify@1.0.8/dist/jquery.contextify.min.js"></script>
 ```
 
 ### Install with Bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery-contextify.

Feel free to ping me if you have any questions regarding this change.